### PR TITLE
モジュールの場合 GitHub リンクにローカルパスが含まれる問題を解決

### DIFF
--- a/src/main/kotlin/com/github/kawamataryo/copygitlink/gitlink/GitLink.kt
+++ b/src/main/kotlin/com/github/kawamataryo/copygitlink/gitlink/GitLink.kt
@@ -38,8 +38,7 @@ class GitLink(actionEvent: AnActionEvent) {
     val relativePath: String
         get() {
             val path = virtualFile.path
-            val basePath = project.basePath ?: ""
-            return path.replace(basePath, "")
+            return path.replace(repo.toString(), "")
         }
 
     val permalink: String


### PR DESCRIPTION
## 概要

複数の Git リポジトリで構成されるプロジェクトの場合、Copy Git Link で取得した GitHub リンクにローカルパスが含まれる問題を解決しました。

## 再現手順

1. Run IDE for UI Tests を実行
2. File > New > Project
3. 任意の空のディレクトリを選択して Empty Project を作成
4. 作成した Empty Project を開く
5. File > New > Module from Existing Sources
6. 任意の Git プロジェクトを選択
7. 追加したモジュールの任意のファイルで Copy Git Link を実行

## 動作確認

Run IDE for UI Tests で動かして動作確認済みです。

- プロジェクトのトップ = Git リポジトリのトップの構成でも GitHub リンクが取得できること
- モジュールのファイルで GitHub リンクが取得できること
- 複数モジュールで構成されるプロジェクトでも GitHub リンクが取得できること

## その他

- `repo.toString()` よりもいい感じにローカルの Git リポジトリのフルパスを取得できる方法があればそちらを採用したいです
    - ログ出力しながら動かして、 `repo.toString()` でたまたま欲しい文字列が取得できたというレベルなので 😓 