### PR TITLE
fix: wrong URL on Windows

### DIFF
--- a/src/main/kotlin/com/github/kawamataryo/copygitlink/gitlink/GitLink.kt
+++ b/src/main/kotlin/com/github/kawamataryo/copygitlink/gitlink/GitLink.kt
@@ -38,7 +38,7 @@ class GitLink(actionEvent: AnActionEvent) {
     val relativePath: String
         get() {
             val path = virtualFile.path
-            return path.replace(repo.toString(), "")
+            return path.replace(repo?.root?.path ?: "", "")
         }
 
     val permalink: String


### PR DESCRIPTION
## 🎯 Purpose

* Copied URL is wrong on Windows.
  * for example: `https://github.com/kawamataryo/copy-git-link/blob/7df63fc5d9d1ffea8362d9c2f6222b29b9540723/C:/Users/mallowlabs/git/copy-git-link/src/main/kotlin/com/github/kawamataryo/copygitlink/gitlink/GitLink.kt#L41`
* This PR will fix it

## 👓 Strategy

* The reason is the path separator.
  * `virtualFile.path`
    *  -> `C:/Users/mallowlabs/git/copy-git-link/src/main/kotlin/com/github/kawamataryo/copygitlink/gitlink/GitLink.kt` (slash-separated)
  * `repo.toString()`
    *  -> `C:\Users\mallowlabs\git\copy-git-link` (backslash-separated)
* So I use `repo?.root?.path`
  *  -> `C:/Users/mallowlabs/git/copy-git-link`(slash-separated)

## ✔️ Tested

* Copied URL on Windows is correct.
* Copied URL on macOS is correct.
* Copied URL in git submodule is correct.
