### PR TITLE
Update regex to handle link with port

### DIFF
--- a/src/main/kotlin/com/github/kawamataryo/copygitlink/gitlink/GitLink.kt
+++ b/src/main/kotlin/com/github/kawamataryo/copygitlink/gitlink/GitLink.kt
@@ -30,7 +30,7 @@ class GitLink(actionEvent: AnActionEvent) {
         get() {
             val url = repo?.remotes?.first()?.firstUrl ?: ""
             val result =
-                Regex(".*(?:@|\\/\\/)(.[^:\\/]*)(?::[0-9]{1,4}).([^\\.]+)\\.git").matchEntire(
+                Regex(".*(?:@|\\/\\/)(.[^:\\/]*)(?::[0-9]{1,4})?.([^\\.]+)\\.git").matchEntire(
                     url
                 )
             return result?.groupValues?.get(1) + "/" + result?.groupValues?.get(2) ?: ""

--- a/src/main/kotlin/com/github/kawamataryo/copygitlink/gitlink/GitLink.kt
+++ b/src/main/kotlin/com/github/kawamataryo/copygitlink/gitlink/GitLink.kt
@@ -30,7 +30,7 @@ class GitLink(actionEvent: AnActionEvent) {
         get() {
             val url = repo?.remotes?.first()?.firstUrl ?: ""
             val result =
-                Regex(".*(?:@|\\/\\/)(.[^:\\/]*).([^\\.]+)\\.git").matchEntire(
+                Regex(".*(?:@|\\/\\/)(.[^:\\/]*)(?::[0-9]{1,4}).([^\\.]+)\\.git").matchEntire(
                     url
                 )
             return result?.groupValues?.get(1) + "/" + result?.groupValues?.get(2) ?: ""


### PR DESCRIPTION
When repo url contains a port, link is generated incorrectly. So for url:
`ssh://git@main.gitlab.in.example.com:1234/ex/some-repository.git`
next link will be generated: `https://main.gitlab.in.example.com/1234/ex/some-repository/...`