### PR TITLE
remove port from repository path to access the copied URL

### DIFF
--- a/src/main/kotlin/com/github/kawamataryo/copygitlink/utils/utils.kt
+++ b/src/main/kotlin/com/github/kawamataryo/copygitlink/utils/utils.kt
@@ -41,5 +41,5 @@ fun getRepositoryPathFromRemoteUrl(
         Regex(".*(?:@|//)(.[^:/]*)(:?:[0-9]{1,4})?.([^.]+)(\\.git)?\$").matchEntire(
             remoteUrl
         )
-    return result?.groupValues?.get(1) + result?.groupValues?.get(2) + "/" + result?.groupValues?.get(3) ?: ""
+    return result?.groupValues?.get(1) + "/" + result?.groupValues?.get(3) ?: ""
 }

--- a/src/test/kotlin/com/github/kawamataryo/copygitlink/utils/utilsTest.kt.kt
+++ b/src/test/kotlin/com/github/kawamataryo/copygitlink/utils/utilsTest.kt.kt
@@ -18,7 +18,7 @@ class UtilsKtTest {
         "ssh://git@github.com:user/repo.git, github.com/user/repo",
         "git://github.com/user/repo.git, github.com/user/repo",
         "https://github.com/YandexClassifieds/projectname, github.com/YandexClassifieds/projectname",
-        "https://gitlab.self-hosted.com:8443/projgroup/projectname, gitlab.self-hosted.com:8443/projgroup/projectname",
+        "https://gitlab.self-hosted.com:8443/projgroup/projectname, gitlab.self-hosted.com/projgroup/projectname",
     )
     fun testGetRepositoryPathFromRemoteUrl(remoteUrl: String, expectedPath: String) {
         val actualPath = getRepositoryPathFromRemoteUrl(remoteUrl)


### PR DESCRIPTION
resolve #19 

I removed port number part from repository path to access the copied URL and modified test case.

I tested following steps.

1. change remote url

```sh
git remote set-url ssh://git@git.company.com:1122/products/path/cpp-edr-test.git
```

2. perform `Copy Permalink` action

3. check copied URL and the URL is like working address (shown in #19 )

```
https://git.company.com/products/path/cpp-edr-test/blob/840f5c7136489a906cd11ace620253d368a7ed46/README.md#L36
```
