### PR TITLE
Use current selection as link text for HTML and Markdown links

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,7 +35,7 @@ dependencies {
 
 // Set the JVM language level used to build the project. Use Java 11 for 2020.3+, and Java 17 for 2022.2+.
 kotlin {
-    jvmToolchain(11)
+    jvmToolchain(17)
 }
 
 // Configure Gradle IntelliJ Plugin - read more: https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html
@@ -125,7 +125,8 @@ tasks {
         // The pluginVersion is based on the SemVer (https://semver.org) and supports pre-release labels, like 2.1.7-alpha.3
         // Specify pre-release label to publish the plugin in a custom Release Channel automatically. Read more:
         // https://plugins.jetbrains.com/docs/intellij/deployment.html#specifying-a-release-channel
-        channels.set(properties("pluginVersion").map { listOf(it.split('-').getOrElse(1) { "default" }.split('.').first()) })
+        val channel = properties("pluginVersion").get().split('-').getOrElse(1) { "default" }.split('.').first()
+        channels.add(channel)
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,11 +7,11 @@ pluginRepositoryUrl = https://github.com/kawamataryo/copy-git-link
 pluginVersion = 0.5.3
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
-pluginSinceBuild = 211
+pluginSinceBuild = 222
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = IC
-platformVersion = 2022.1.4
+platformVersion = 2022.2.5
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
@@ -19,6 +19,9 @@ platformPlugins = Git4Idea
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
 gradleVersion = 8.0.2
+
+# Java toolchain
+org.gradle.java.home=/home/maxim.galkin/.jdks/jbr-17.0.14
 
 # Opt-out flag for bundling Kotlin standard library -> https://jb.gg/intellij-platform-kotlin-stdlib
 # suppress inspection "UnusedProperty"

--- a/src/main/kotlin/com/github/kawamataryo/copygitlink/CopyGitLinkAsHtml.kt
+++ b/src/main/kotlin/com/github/kawamataryo/copygitlink/CopyGitLinkAsHtml.kt
@@ -4,7 +4,9 @@ import GitLink
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.CommonDataKeys
 import copyToClipboard
+import getLinkTextFromEditor
 import showNotification
 import truncateText
 
@@ -14,7 +16,8 @@ class CopyPermalinkAsHtml : AnAction() {
 
         if (gitLink.hasRepository) {
             val permalink = gitLink.permalink
-            val linkText = gitLink.relativePath + gitLink.linePath
+            val editor = e.getData(CommonDataKeys.EDITOR)
+            val linkText = getLinkTextFromEditor(editor, gitLink.relativePath + gitLink.linePath)
 
             // Copy to clipboard
             copyToClipboard("<a href='$permalink'>$linkText</a>")

--- a/src/main/kotlin/com/github/kawamataryo/copygitlink/CopyPermalinkAsMarkdown.kt
+++ b/src/main/kotlin/com/github/kawamataryo/copygitlink/CopyPermalinkAsMarkdown.kt
@@ -4,7 +4,9 @@ import GitLink
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.CommonDataKeys
 import copyToClipboard
+import getLinkTextFromEditor
 import showNotification
 import truncateText
 
@@ -15,7 +17,8 @@ class CopyPermalinkAsMarkdown : AnAction() {
 
         if (gitLink.hasRepository) {
             val permalink = gitLink.permalink
-            val linkText = gitLink.relativePath + gitLink.linePath
+            val editor = e.getData(CommonDataKeys.EDITOR)
+            val linkText = getLinkTextFromEditor(editor, gitLink.relativePath + gitLink.linePath)
             val markdownLink = "[$linkText]($permalink)"
 
             copyToClipboard(markdownLink)

--- a/src/main/kotlin/com/github/kawamataryo/copygitlink/utils/utils.kt
+++ b/src/main/kotlin/com/github/kawamataryo/copygitlink/utils/utils.kt
@@ -1,8 +1,10 @@
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationListener
 import com.intellij.notification.NotificationType
+import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.ide.CopyPasteManager
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.TextRange
 import java.awt.datatransfer.StringSelection
 
 fun showNotification(project: Project, type: NotificationType, title: String, content: String) {
@@ -23,6 +25,22 @@ fun truncateText(text: String, maxLength: Int): String {
         return text
     }
     return "${text.substring(0, maxLength)}..."
+}
+
+fun getLinkTextFromEditor(editor: Editor?, fallback: String): String {
+    return editor?.let {
+        val selectionModel = it.selectionModel
+        if (selectionModel.hasSelection()) {
+            selectionModel.selectedText?.trim()
+        } else {
+            val document = it.document
+            val lineNumber = it.caretModel.logicalPosition.line
+            document.getText(TextRange(
+                document.getLineStartOffset(lineNumber),
+                document.getLineEndOffset(lineNumber)
+            )).trim()
+        }
+    }?.takeIf { it.isNotEmpty() } ?: fallback
 }
 
 fun getPermalink(

--- a/src/main/kotlin/com/github/kawamataryo/copygitlink/utils/utils.kt
+++ b/src/main/kotlin/com/github/kawamataryo/copygitlink/utils/utils.kt
@@ -31,7 +31,10 @@ fun getLinkTextFromEditor(editor: Editor?, fallback: String): String {
     return editor?.let {
         val selectionModel = it.selectionModel
         if (selectionModel.hasSelection()) {
-            selectionModel.selectedText?.trim()
+            selectionModel.selectedText
+                ?.lines()
+                ?.firstOrNull()
+                ?.trim()
         } else {
             val document = it.document
             val lineNumber = it.caretModel.logicalPosition.line


### PR DESCRIPTION
This will modify "Copy as HTML" and "Copy as MD" functions to add a currently selected text as link text instead of original filename+line (`CopyAsMarkdownWithCode.kt#L41`).

Example:
<img width="610" height="104" alt="image" src="https://github.com/user-attachments/assets/10db9491-35f9-4e21-9ddd-3f55f3b1b804" />
With the current selection, markdown link will look like:
```md
[showNotification](https://github.com/MaximGalkin-TomTom/personal-copy-git-link/blob/f2001c4e704a501dffe17b09f13d26791eeb2eea/src/main/kotlin/com/github/kawamataryo/copygitlink/CopyAsMarkdownWithCode.kt#L41)
```
And as a link will be: [showNotification](https://github.com/MaximGalkin-TomTom/personal-copy-git-link/blob/f2001c4e704a501dffe17b09f13d26791eeb2eea/src/main/kotlin/com/github/kawamataryo/copygitlink/CopyAsMarkdownWithCode.kt#L41)

Implemented:
- if multi-line text is selected, first line will be used as link text
- if part of the line is selected, it will be used as link text
- if nothing is selected, current line under cursor will be used as a link text
- if editor is unavailable (IDK why), then original implementation with filename and line number will be used as link text

PS: I also bumped JVM and platform versions to match latest environment, please remove these changes if they are not desired